### PR TITLE
adds dark mode

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -276,7 +276,7 @@ website:
 format:
   html:
     theme:
-      - litera
-      - html/custom.scss
+      light: [litera, html/custom.scss]
+      dark: darkly
     toc: true
     highlight-style: monokai


### PR DESCRIPTION
adds dark mode, quarto will just add a slider at the top right of the page, should still default to the first theme "light" which is your native litera and html/custom.scss. Additionally, you could add your custom.scss file to the dark mode theme, but the colors may contrast with darkly... or not.  I wasn't able to build the full site without installing 20+ dependencies so i was only able to test on the "index.html" main page. It looked good enough without the custom.scss so i left it out. if you are able to build the full site locally then you'll be able to experiment more thoroughly than I.